### PR TITLE
Make ObjectsList order small areas before overlapping larger ones on hover

### DIFF
--- a/web/_js/view.js
+++ b/web/_js/view.js
@@ -345,7 +345,9 @@ function initView(){
 				}
 
 				if(changed){
-					hovered = newHovered;
+					hovered = newHovered.sort(function(a, b){
+						return calcPolygonArea(a.path) - calcPolygonArea(b.path);
+					});
 
 					objectsContainer.innerHTML = "";
 


### PR DESCRIPTION
There is room to improve performance later if/when `calcPolygonArea()` data is available for all entries on page load.

Closes: #1030