### PR TITLE
Adds 2 secret diff modes for easier preview checking

### DIFF
--- a/web/_js/view.js
+++ b/web/_js/view.js
@@ -114,8 +114,23 @@ function renderBackground(atlas){
 
 		backgroundContext.closePath();
 
-		backgroundContext.strokeStyle = "rgba(255, 255, 255, 0.8)";
+		var bgStrokeStyle;
+		switch (atlas[i].diff) {
+			case "add":
+				bgStrokeStyle = "rgba(0, 255, 0, 1)";
+				backgroundContext.lineWidth = 2;
+				break;
+			case "edit":
+				bgStrokeStyle = "rgba(255, 255, 0, 1)";
+				backgroundContext.lineWidth = 2;
+				break;
+			default:
+				bgStrokeStyle = "rgba(255, 255, 255, 0.8)";
+				break;
+		}
+		backgroundContext.strokeStyle = bgStrokeStyle;
 		backgroundContext.stroke();
+		backgroundContext.lineWidth = 1;
 	}
 }
 
@@ -691,7 +706,19 @@ function initView(){
 
 			context.globalCompositeOperation = "source-over";
 
-			context.strokeStyle = "rgba(0, 0, 0, 1)";
+			var hoverStrokeStyle;
+			switch (hovered[i].diff) {
+				case "add":
+					hoverStrokeStyle = "rgba(0, 155, 0, 1)";
+					break;
+				case "edit":
+					hoverStrokeStyle = "rgba(155, 155, 0, 1)";
+					break;
+				default:
+					hoverStrokeStyle = "rgba(0, 0, 0, 1)";
+					break;
+			}
+			context.strokeStyle = hoverStrokeStyle;
 			//context.lineWidth = zoom;
 			context.stroke();
 		}


### PR DESCRIPTION
Add 2 new modes that display a diff of sorts meant to be used with preview deploys to allow for easy verification of additions and edits especially useful when it comes to checking for new duplicates and edited/added boarder grief.

When enabled either mode will highlight new and edited entries as compared to the live sights JSON data.
Green = new
Yellow = edited

`?mode=diff` looks like this:
![chrome_QX07D8g4NC](https://user-images.githubusercontent.com/64715958/162360963-b8cd95f9-0bce-435b-99b8-3b882cf72096.png)

`?mode=diffonly` looks like this:
![chrome_9T46e1zb2d](https://user-images.githubusercontent.com/64715958/162360991-f86e0d91-a920-4062-ae61-4a4bdc95c674.png)

Closes: #1020 
@nico-abram 