### PR TITLE
Add auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+version: v1
+
+labels:
+  - label: "Website Improvements"
+    matcher:
+      files:
+        any: [ "web/**" ]
+        all: [ "!web/atlas.json" ]
+  - label: "Tooling"
+    matcher:
+      files:
+        any: [ "tools/**", ".github/workflows/**" ]
+  - label: "SUBMIT ON REDDIT"
+    matcher:
+      title: "^[Aa]dd(ing|ed|s)?"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request_target:
+    types:
+        - opened
+  pull_request:
+    types:
+        - opened
+  issues:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  statuses: write
+  checks: write
+
+jobs:
+  labeler:
+    name: Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fuxingloh/multi-labeler@v1


### PR DESCRIPTION
There's no way to differentiate between a cleanup branch merge and a usual contribution (I couldn't check the base or the destination, I could check the authors but, eehhh...), so it won't add those. However, I did add "SUBMIT ON REDDIT" labels, which collaborators can close after. It only triggers once, so collaborators can override it.