### PR TITLE
Use hash URL (#) for id highlight

### DIFF
--- a/web/_js/infoblock.js
+++ b/web/_js/infoblock.js
@@ -31,7 +31,7 @@ function createInfoBlock(entry) {
 
     let headerElement = document.createElement("h2");
     let linkElement = document.createElement("a");
-    linkElement.href = "?id=" + entry.id;
+    linkElement.href = "#id=" + entry.id;
     linkElement.innerText = entry.name;
     headerElement.appendChild(linkElement);
 

--- a/web/_js/infoblock.js
+++ b/web/_js/infoblock.js
@@ -31,7 +31,7 @@ function createInfoBlock(entry) {
 
     let headerElement = document.createElement("h2");
     let linkElement = document.createElement("a");
-    linkElement.href = "#id=" + entry.id;
+    linkElement.href = "#" + entry.id;
     linkElement.innerText = entry.name;
     headerElement.appendChild(linkElement);
 

--- a/web/_js/main.js
+++ b/web/_js/main.js
@@ -110,6 +110,14 @@ async function init(){
 		} else {
 			mode = "view";
 		}
+
+		// Backwards compatibility for old links using "search" id arg
+		if(args.includes("id=")){
+			let idHash = "id=" + args.split("id=")[1].split("&")[0];
+			window.location.hash = idHash;
+			let idArgMatch = new RegExp(`${idHash}&?`); // Patten for the id plus a following & if present
+			window.location.search = window.location.search.substring(1).replace(idArgMatch, "");
+		}
 	}
 
 	document.body.dataset.mode = mode

--- a/web/_js/main.js
+++ b/web/_js/main.js
@@ -113,9 +113,9 @@ async function init(){
 
 		// Backwards compatibility for old links using "search" id arg
 		if(args.includes("id=")){
-			let idHash = "id=" + args.split("id=")[1].split("&")[0];
+			let idHash = args.split("id=")[1].split("&")[0];
 			window.location.hash = idHash;
-			let idArgMatch = new RegExp(`${idHash}&?`); // Patten for the id plus a following & if present
+			let idArgMatch = new RegExp(`id=${idHash}&?`); // Patten for the id plus a following & if present
 			window.location.search = window.location.search.substring(1).replace(idArgMatch, "");
 		}
 	}

--- a/web/_js/overlap.js
+++ b/web/_js/overlap.js
@@ -27,12 +27,8 @@ function initOverlap(){
 	render();
 	updateLines();
 
-	var args = window.location.hash;
-	if(args){
-		id = args.split("id=")[1];
-		if(id){
-			highlightEntryFromUrl();
-		}
+	if(window.location.hash){
+		highlightEntryFromUrl();
 	}
 
 	function renderBackground(atlas) {

--- a/web/_js/overlap.js
+++ b/web/_js/overlap.js
@@ -27,7 +27,7 @@ function initOverlap(){
 	render();
 	updateLines();
 
-	var args = window.location.search;
+	var args = window.location.hash;
 	if(args){
 		id = args.split("id=")[1];
 		if(id){

--- a/web/_js/view.js
+++ b/web/_js/view.js
@@ -53,6 +53,7 @@ var defaultSort = "shuffle";
 document.getElementById("sort").value = defaultSort;
 
 var lastPos = [0, 0];
+var idLastHighlight; // track the last id to prevent highlighting from different hash arg updates
 
 var fixed = false; // Fix hovered items in place, so that clicking on links is possible
 
@@ -672,13 +673,15 @@ function updateHovering(e, tapped){
 	}
 }
 
+window.addEventListener("hashchange", highlightEntryFromUrl);
+
 function highlightEntryFromUrl(){
 
 	var objectsContainer = document.getElementById("objectsList");
 
 	var id = 0;
 	
-	var args = window.location.search;
+	var args = window.location.hash;
 	if(args){
 		id = args.split("id=")[1];
 		if(id){
@@ -686,8 +689,11 @@ function highlightEntryFromUrl(){
 		}
 	}
 
-	//var id = parseInt(window.location.hash.substring(3));
-	
+	if(id === idLastHighlight){
+		return;
+	}
+	idLastHighlight = id;
+
 	var entries = atlas.filter(function(e){
 		return e.id === id;
 	});
@@ -752,7 +758,7 @@ function initView(){
 	render();
 	updateLines();
 
-	var args = window.location.search;
+	var args = window.location.hash;
 	if(args){
 		id = args.split("id=")[1];
 		if(id){

--- a/web/_js/view.js
+++ b/web/_js/view.js
@@ -744,8 +744,7 @@ function initView(){
 	render();
 	updateLines();
 
-	var args = window.location.hash;
-	if(args){ // both "/" and just "/#" will be an empty hash string
+	if(window.location.hash){ // both "/" and just "/#" will be an empty hash string
 		highlightEntryFromUrl();
 	}
 

--- a/web/_js/view.js
+++ b/web/_js/view.js
@@ -53,7 +53,6 @@ var defaultSort = "shuffle";
 document.getElementById("sort").value = defaultSort;
 
 var lastPos = [0, 0];
-var idLastHighlight; // track the last id to prevent highlighting from different hash arg updates
 
 var fixed = false; // Fix hovered items in place, so that clicking on links is possible
 
@@ -679,20 +678,7 @@ function highlightEntryFromUrl(){
 
 	var objectsContainer = document.getElementById("objectsList");
 
-	var id = 0;
-	
-	var args = window.location.hash;
-	if(args){
-		id = args.split("id=")[1];
-		if(id){
-			id = id.split("&")[0];
-		}
-	}
-
-	if(id === idLastHighlight){
-		return;
-	}
-	idLastHighlight = id;
+	var id = window.location.hash.substring(1); //Remove hash prefix
 
 	var entries = atlas.filter(function(e){
 		return e.id === id;
@@ -759,11 +745,8 @@ function initView(){
 	updateLines();
 
 	var args = window.location.hash;
-	if(args){
-		id = args.split("id=")[1];
-		if(id){
-			highlightEntryFromUrl();
-		}
+	if(args){ // both "/" and just "/#" will be an empty hash string
+		highlightEntryFromUrl();
 	}
 
 }


### PR DESCRIPTION
### Pros:

- Less page refreshes when clicking entry titles to highlight.
- Very nice to have when border hunting overlaps.
- Opens the door for smooth "crosslinks" ala a wiki article style where descriptions can have links to other entries ids.

### Cons:

- The current way of highlighting has inertia so those links still need to be handled too.
    - Included in this PR.
- There is a reason we decided to not use hash to begin with I am unaware of?