### PR TITLE
Fix the filenames in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ To contribute to the map, we require a certain format for artwork region and lab
 ### GitHub Submission
 
 1. Create a fork of our repo.
-2. Enter your data into the `web/_js/atlas.js` file, with the correct format and ID number.
+2. Enter your data into the `web/atlas.json` file, with the correct format and ID number.
 3. Create a Pull Request.
 
 -->
@@ -27,7 +27,7 @@ To contribute to the map, we require a certain format for artwork region and lab
 ## Map Edits
 
 1. Create a fork of our repo.
-2. Enter your data into the `web/_js/atlas.json` file, with the correct format and ID number.
+2. Enter your data into the `web/atlas.json` file, with the correct format and ID number.
 3. Create a Pull Request against the `/cleanup` branch.
 
 ## Cleaning Contributions


### PR DESCRIPTION
The data for each submission is stored in `web/atlas.json`, whereas `web/_js/atlas.js` is a source code file (which I assume, used to hold the data until it was moved to a separate file).

I believe this should be merged into the `master` branch, but let me know if otherwise and I can update the base branch.