### PR TITLE
Fix stretching due to Netlify's new badges

### DIFF
--- a/web/about.html
+++ b/web/about.html
@@ -219,7 +219,7 @@
 						  <div class="p-4">
 							<h4>Deployment</h4>
 							<p>This site is powered by Netlify.</p>
-							<a class="d-flex flex-wrap justify-content-left gap-2" href="https://www.netlify.com" target="_blank" rel="noopener">
+							<a class="d-flex flex-wrap align-items-center justify-content-left gap-2" href="https://www.netlify.com" target="_blank" rel="noopener">
 								<img src="https://www.netlify.com/img/global/badges/netlify-color-bg.svg" alt="Deploys by Netlify" />
 								<img src="https://api.netlify.com/api/v1/badges/1e7291ce-0680-45ed-9843-47a32a992bbb/deploy-status" type="image/svg+xml" alt="Netlify status" />
 							</a>


### PR DESCRIPTION
Hello, 2023! Sorry for the dormancy.

The Netlify's new badges introduces a taller badge, resulting in stretching of the status badge. This PR fixes it.