### PR TITLE
Add redirect to 2022.place-atlas.stefanocoding.me

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ You may contribute to the project by submitting a Pull Request on the GitHub rep
 
 ## New Atlas entries
 
-To contribute to the map, we require a certain format for artwork region and labels. This can be generated on [the drawing mode](https://place-atlas.stefanocoding.me?mode=draw) on the website. 
+To contribute to the map, we require a certain format for artwork region and labels. This can be generated on [the drawing mode](https://2022.place-atlas.stefanocoding.me?mode=draw) on the website. 
 
-To add a new entry, go to [the drawing mode](https://place-atlas.stefanocoding.me?mode=draw) and draw a shape/polygon around the region you'd like to describe. You can use the <kbd>Undo</kbd>, <kbd>Redo</kbd>, and <kbd>Reset</kbd> buttons to help you creating a good polygon. Make sure that the lines you're drawing don't form a [self-intersecting polygon](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Complex_polygon.svg/288px-Complex_polygon.svg.png). 
+To add a new entry, go to [the drawing mode](https://2022.place-atlas.stefanocoding.me?mode=draw) and draw a shape/polygon around the region you'd like to describe. You can use the <kbd>Undo</kbd>, <kbd>Redo</kbd>, and <kbd>Reset</kbd> buttons to help you creating a good polygon. Make sure that the lines you're drawing don't form a [self-intersecting polygon](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0f/Complex_polygon.svg/288px-Complex_polygon.svg.png). 
 
 Multiple periods can be added to represent the changing state of the artwork on different times. You can set the start and end period, as well as chosing the appropriate canvas variations. You can also copy the polygon from one period to the other, duplicating a period to be edited later, as well as deleting a period (if there is more than one). An alert is also shown if there are errors for assistance.
 
@@ -76,7 +76,7 @@ Edits are also welcome on this repository using Git through GitHub. You may use 
 
 Upon creating a fork of this repository and pushing the changes, create a pull request towards the `cleanup` branch. A member will merge the pull request if it is adequate.
 
-To help find duplicates, [use the Overlap mode](https://place-atlas.stefanocoding.me?mode=overlap).
+To help find duplicates, [use the Overlap mode](https://2022.place-atlas.stefanocoding.me?mode=overlap).
 
 ### Example
 
@@ -107,8 +107,8 @@ Hereforth is an example of the structured data. The example has been expanded, b
 ```
 
 `109-166, T:0-1` has this meaning.
-  - `109-166`: Default canvas variation (r/place), period [109](https://place-atlas.stefanocoding.me/#/109) to [166](https://place-atlas.stefanocoding.me/#/166).
-  - `T:0-1`: "The Final Clean" canvas variation, period [0](https://place-atlas.stefanocoding.me/#/T:0) (The Final Clean) to [1](https://place-atlas.stefanocoding.me/#/T:1) (Unofficial Corrections).
+  - `109-166`: Default canvas variation (r/place), period [109](https://2022.place-atlas.stefanocoding.me/#/109) to [166](https://2022.place-atlas.stefanocoding.me/#/166).
+  - `T:0-1`: "The Final Clean" canvas variation, period [0](https://2022.place-atlas.stefanocoding.me/#/T:0) (The Final Clean) to [1](https://2022.place-atlas.stefanocoding.me/#/T:1) (Unofficial Corrections).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Entry count](https://img.shields.io/badge/dynamic/json?color=blue&label=entries&query=%24.length&url=https%3A%2F%2Fgithub.com%2FplaceAtlas%2Fatlas%2Fblob%2Fmaster%2Fweb%2Fatlas.json%3Fraw%3Dtrue)](https://place-atlas.stefanocoding.me/)
+[![Entry count](https://img.shields.io/badge/dynamic/json?color=blue&label=entries&query=%24.length&url=https%3A%2F%2Fgithub.com%2FplaceAtlas%2Fatlas%2Fblob%2Fmaster%2Fweb%2Fatlas.json%3Fraw%3Dtrue)](https://2022.place-atlas.stefanocoding.me/)
 ![Commit activity](https://img.shields.io/github/commit-activity/w/placeAtlas/atlas)
 [![Netlify](https://img.shields.io/netlify/1e7291ce-0680-45ed-9843-47a32a992bbb?logo=netlify&logoColor=white)](https://app.netlify.com/sites/place-atlas/deploys)
 [![License](https://img.shields.io/github/license/placeAtlas/atlas)](https://github.com/placeAtlas/atlas/blob/master/LICENSE)  
 [![Discord](https://img.shields.io/discord/960791635342524496?color=%235865F2&logo=discord&logoColor=white)](https://discord.gg/pJkm23b2nA)
 [![Subreddit subscribers](https://img.shields.io/reddit/subreddit-subscribers/placeAtlas2?color=%23FF4500&label=r%2FplaceAtlas2&logo=reddit&logoColor=white)](https://www.reddit.com/r/placeAtlas2/)
-[![Website](https://img.shields.io/static/v1?label=website&message=place-atlas.stefanocoding.me&color=blue)](https://place-atlas.stefanocoding.me/)
+[![Website](https://img.shields.io/static/v1?label=website&message=2022.place-atlas.stefanocoding.me&color=blue)](https://2022.place-atlas.stefanocoding.me/)
 
 # The 2022 r/place Atlas
 
@@ -14,7 +14,7 @@ This project was established by Roland Rytz for the event in 2017, and further d
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).
 
-You can check out the website by visiting [place-atlas.stefanocoding.me](https://place-atlas.stefanocoding.me/). If you want to keep distance from GitHub, you may visit [r/placeAtlas2](https://www.reddit.com/r/placeAtlas2/).
+You can check out the website by visiting [2022.place-atlas.stefanocoding.me](https://2022.place-atlas.stefanocoding.me/). If you want to keep distance from GitHub, you may visit [r/placeAtlas2](https://www.reddit.com/r/placeAtlas2/).
 
 ## Contributing
 
@@ -53,4 +53,4 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. This section only includes GitHub contributions. Other credits are shown on [the About page](https://place-atlas.stefanocoding.me/about).
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. This section only includes GitHub contributions. Other credits are shown on [the About page](https://2022.place-atlas.stefanocoding.me/about).

--- a/tools/unused/area-chart.svg
+++ b/tools/unused/area-chart.svg
@@ -151,7 +151,7 @@
          sodipodi:role="line"
          id="tspan3904"
          x="721.92651"
-         y="511.92819">http://place-atlas.stefanocoding.me/</tspan></text>
+         y="511.92819">http://2022.place-atlas.stefanocoding.me/</tspan></text>
     <g
        id="g3927"
        transform="translate(-80.812204,0)">
@@ -178,7 +178,7 @@
            y="810.95184"
            x="940.96014"
            id="tspan3904-9"
-           sodipodi:role="line">http://place-atlas.stefanocoding.me/</tspan></text>
+           sodipodi:role="line">http://2022.place-atlas.stefanocoding.me/</tspan></text>
     </g>
   </g>
 </svg>

--- a/tools/unused/smallifier.html
+++ b/tools/unused/smallifier.html
@@ -3,7 +3,7 @@
 	The 2022 r/place Atlas
 	Copyright (c) 2017 Roland Rytz <roland@draemm.li>
 	Copyright (c) 2022 Place Atlas contributors
-	Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+	Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
 -->
 
 <!--

--- a/web/_css/style.css
+++ b/web/_css/style.css
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 /* purgecss start ignore */

--- a/web/_js/about.js
+++ b/web/_js/about.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const contributorsEl = document.querySelector('#contributors-wrapper')

--- a/web/_js/config.js
+++ b/web/_js/config.js
@@ -2,7 +2,7 @@
 // Please also check code indicated with "@instance-only" outside this file.
 // TODO: Avoid having instance-only code inside the main scripts to make updating easier.
 
-const prodDomain = "place-atlas.stefanocoding.me"
+const prodDomain = "2022.place-atlas.stefanocoding.me"
 window.prodDomain = prodDomain
 
 const instanceId = "2022"
@@ -260,9 +260,9 @@ window.useNumericalId = useNumericalId
 console.info(`%cThe 2022 r/place Atlas
 %cCopyright (c) 2017 Roland Rytz <roland@draemm.li>
 Copyright (c) 2022 Place Atlas contributors
-Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
 
-https://place-atlas.stefanocoding.me/
+https://2022.place-atlas.stefanocoding.me/
 https://discord.gg/pJkm23b2nA
 https://reddit.com/r/placeatlas2
 https://github.com/placeAtlas/atlas

--- a/web/_js/config.js
+++ b/web/_js/config.js
@@ -254,7 +254,7 @@ window.defaultVariation = defaultVariation
 let defaultPeriod = variationsConfig[defaultVariation].default
 window.defaultPeriod = defaultPeriod
 
-const useNumericalId = false
+const useNumericalId = true
 window.useNumericalId = useNumericalId
 
 console.info(`%cThe 2022 r/place Atlas

--- a/web/_js/main/atlas.js
+++ b/web/_js/main/atlas.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 window.addEventListener("error", e => {

--- a/web/_js/main/draw.js
+++ b/web/_js/main/draw.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const finishButton = document.getElementById("finishButton")

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const baseLinkElement = document.createElement("a")

--- a/web/_js/main/main.js
+++ b/web/_js/main/main.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const innerContainer = document.getElementById("innerContainer")

--- a/web/_js/main/overlap.js
+++ b/web/_js/main/overlap.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 function initOverlap() {

--- a/web/_js/main/stats.js
+++ b/web/_js/main/stats.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 let areasSum = 0
@@ -203,7 +203,7 @@ console.info("The " + topCount + " largest entries:")
 let outstring = ""
 
 for (let i = 0; i < topCount; i++) {
-	outstring += ((i + 1) + "|[" + atlas[atlas.length - i - 1].name + "](http://place-atlas.stefanocoding.me/?id=" + atlas[atlas.length - i - 1].id + ")|" + ~~atlas[atlas.length - i - 1].area + "|" + Math.round(atlas[atlas.length - i - 1].area / 100) / 100 + "%\n")
+	outstring += ((i + 1) + "|[" + atlas[atlas.length - i - 1].name + "](http://2022.place-atlas.stefanocoding.me/?id=" + atlas[atlas.length - i - 1].id + ")|" + ~~atlas[atlas.length - i - 1].area + "|" + Math.round(atlas[atlas.length - i - 1].area / 100) / 100 + "%\n")
 }
 
 console.info(outstring)

--- a/web/_js/main/time.js
+++ b/web/_js/main/time.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const codeReference = {}

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -676,7 +676,7 @@ function highlightEntryFromUrl() {
 	if (!id) return
 
 	const entries = atlas.filter(e => {
-		return e.id === id
+		return e.id.toString() === id
 	})
 
 	if (entries.length !== 1) return 

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -2,7 +2,7 @@
  * The 2022 r/place Atlas
  * Copyright (c) 2017 Roland Rytz <roland@draemm.li>
  * Copyright (c) 2022 Place Atlas contributors
- * Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+ * Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
  */
 
 const linesCanvas = document.getElementById("linesCanvas")

--- a/web/_redirects
+++ b/web/_redirects
@@ -1,0 +1,1 @@
+https://place-atlas.stefanocoding.me/*    https://2022.place-atlas.stefanocoding.me/:splat 

--- a/web/about.html
+++ b/web/about.html
@@ -2,7 +2,7 @@
 	The 2022 r/place Atlas
 	Copyright (c) 2017 Roland Rytz <roland@draemm.li>
 	Copyright (c) 2022 Place Atlas contributors
-	Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+	Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
 -->
 
 <!DOCTYPE html>
@@ -17,8 +17,8 @@
 		
 		<meta property="og:title" content="About - The 2022 r/place Atlas">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="https://place-atlas.stefanocoding.me/">
-		<meta property="og:image" content="https://place-atlas.stefanocoding.me/_img/logo.png">
+		<meta property="og:url" content="https://2022.place-atlas.stefanocoding.me/">
+		<meta property="og:image" content="https://2022.place-atlas.stefanocoding.me/_img/logo.png">
 		<meta property="og:image:type" content="image/png">
 		<meta property="og:image:width" content="512">
 		<meta property="og:image:height" content="512">

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 	The 2022 r/place Atlas
 	Copyright (c) 2017 Roland Rytz <roland@draemm.li>
 	Copyright (c) 2022 Place Atlas contributors
-	Licensed under AGPL-3.0 (https://place-atlas.stefanocoding.me/license.txt)
+	Licensed under AGPL-3.0 (https://2022.place-atlas.stefanocoding.me/license.txt)
 -->
 
 <!DOCTYPE html>
@@ -17,8 +17,8 @@
 		
 		<meta property="og:title" content="The 2022 r/place Atlas">
 		<meta property="og:type" content="website">
-		<meta property="og:url" content="https://place-atlas.stefanocoding.me/">
-		<meta property="og:image" content="https://place-atlas.stefanocoding.me/_img/logo.png">
+		<meta property="og:url" content="https://2022.place-atlas.stefanocoding.me/">
+		<meta property="og:image" content="https://2022.place-atlas.stefanocoding.me/_img/logo.png">
 		<meta property="og:image:type" content="image/png">
 		<meta property="og:image:width" content="512">
 		<meta property="og:image:height" content="512">
@@ -49,7 +49,7 @@
 				"@context": "https://schema.org",
 				"@type": "WebSite",
 				"name": "The 2022 r/place Atlas",
-				"url": "https://place-atlas.stefanocoding.me/",
+				"url": "https://2022.place-atlas.stefanocoding.me/",
 				"author": [
 					   {
 							"@type": "Person",
@@ -78,7 +78,7 @@
 						"name": "Place Atlas",
 						"alternateName": "r/placeatlas2",
 						"url": "https://github.com/placeAtlas",
-						"image": "http://place-atlas.stefanocoding.me/_img/logo.png",
+						"image": "http://2022.place-atlas.stefanocoding.me/_img/logo.png",
 						"founder": {
 							"@type": "Person",
 							"@id": "#Codixer",
@@ -94,12 +94,12 @@
 					}
 				],
 				"copyrightYear": 2017,
-				"license": "https://place-atlas.stefanocoding.me/license.txt",
+				"license": "https://2022.place-atlas.stefanocoding.me/license.txt",
 				"inLanguage": "English",
 				"isAccessibleForFree": true,
 				"keywords": "reddit, r/place, place, experiment",
-				"thumbnailUrl": "https://place-atlas.stefanocoding.me/_img/logo.png",
-				"image": "https://place-atlas.stefanocoding.me/_img/logo.png",
+				"thumbnailUrl": "https://2022.place-atlas.stefanocoding.me/_img/logo.png",
+				"image": "https://2022.place-atlas.stefanocoding.me/_img/logo.png",
 				"description": "An interactive map of Reddit's 2022 r/place, with information to each artwork of the canvas."
 			}
 		</script>


### PR DESCRIPTION
Sequel to #1444. I suggest viewing [the commits tab](https://github.com/placeAtlas/atlas/pull/1444/commits) to see (and check) the changes made. Anyone is welcome to test it, as well as giving feedback.

Highlights:
- Changes regarding domain change from `place-atlas.stefanocoding.me` to `2022.place-atlas.stefanocoding.me`.
- Numerical IDs has been finalised, and a critical bug regarding it has been fixed, making it possible again to do `#10`.